### PR TITLE
Fix #64 - [Frontend] - Instance details EBS volume link broken

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,6 +30,9 @@ Build Requirements
 
 * `AWS Credentials <https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html>`_ - API Keys or an AWS instance role with `appropriate permissions <https://www.packer.io/docs/builders/amazon.html>`_.
 
+* An existing VPC and subnet for the packer build instance and eventually the cinq instance to live (can be the same if you wish).
+  TL;DR: *cinq will not create the vpcs/subnets for you*
+
 ^^^^^^^^^^^^^
 1. Setting Up
 ^^^^^^^^^^^^^

--- a/frontend/source/javascript/components/instances/details.html
+++ b/frontend/source/javascript/components/instances/details.html
@@ -94,7 +94,7 @@
             <tbody md-body>
             <tr md-row ng-repeat="volume in vm.instance.volumes | orderBy: 'volumeId'">
                 <td md-cell>
-                    <a href="#" ui-sref="ebs.details({volumeId: volume.volumeId})">{{volume.volumeId}}</a>
+                    <a href="https://console.aws.amazon.com/ec2/v2/?region={{vm.instance.location}}#Volumes:search={{volume.volumeId}}" ui-sref="ebs.details({volumeId: volume.volumeId})">{{volume.volumeId}}</a>
                 </td>
                 <td md-cell>
                     {{volume.size}}


### PR DESCRIPTION
This populates the link to the EBS Volume ID correctly.
