### PR TITLE
Remove unused / internal information from email template

### DIFF
--- a/backend/templates/required_tags_fixed.html
+++ b/backend/templates/required_tags_fixed.html
@@ -33,6 +33,3 @@
         </table>
     </div>
 </div>
-{% if tracking and tracking.enabled %}
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&tid={{tracking.id}}&cid={{tracking.client_id}}&ec={{tracking.category}}&ea={{tracking.action}}&el={{tracking.label}}&z={{tracking.z}}" style="height: 1px; width: 1px;" />
-{% endif %}

--- a/backend/templates/required_tags_fixed.html
+++ b/backend/templates/required_tags_fixed.html
@@ -1,8 +1,6 @@
 <div>
     <p>
-        The following instances are now compliant with the
-        <a href="https://confluence.riotgames.com/display/tech/RFC+0026+-+AWS+Ownership+and+Cost+Attribution">RFC-0026</a>
-        tagging standards and are no longer subject to being stopped.
+        The following instances are now compliant with the Required Tags standards and are no longer subject to being stopped.
     </p>
 
     <div>


### PR DESCRIPTION
* Remove some old, now un-used Google Analytics code from the email templates
* Remove reference to internal documentation for required tags standard

Closes #79 