### PR TITLE
Fix lint warning, remove deprecated npm module

### DIFF
--- a/frontend/gulp/tasks/build/javascript.dev.js
+++ b/frontend/gulp/tasks/build/javascript.dev.js
@@ -15,7 +15,13 @@ const deps = Object.keys(pkg.dependencies);
 
 gulp.task('build.javascript.dev', function () {
     return browserify(config.app)
-        .transform("babelify", {presets: ['es2015']})
+        .transform("babelify", {
+            presets: [['env', {
+                "targets": {
+                    "chrome": "60"
+                }
+            }]]
+        })
         .external(deps)
         .bundle()
         .pipe(source('bundle.js'))

--- a/frontend/gulp/tasks/build/javascript.prod.js
+++ b/frontend/gulp/tasks/build/javascript.prod.js
@@ -17,7 +17,13 @@ const deps = Object.keys(pkg.dependencies);
 
 gulp.task('build.javascript.prod', function () {
     return browserify(config.app)
-        .transform("babelify", {presets: ['es2015']})
+        .transform("babelify", {
+            presets: ['env', {
+                "targets": {
+                    "chrome": "60"
+                }
+            }]
+        })
         .external(deps)
         .bundle()
         .pipe(source('bundle.js'))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -643,6 +643,17 @@
                 }
             }
         },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+            "dev": true,
+            "requires": {
+                "babel-helper-explode-assignable-expression": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+            }
+        },
         "babel-helper-call-delegate": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -665,6 +676,17 @@
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0",
                 "lodash": "4.17.4"
+            }
+        },
+        "babel-helper-explode-assignable-expression": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
             }
         },
         "babel-helper-function-name": {
@@ -721,6 +743,19 @@
                 "lodash": "4.17.4"
             }
         },
+        "babel-helper-remap-async-to-generator": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+            "dev": true,
+            "requires": {
+                "babel-helper-function-name": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+            }
+        },
         "babel-helper-replace-supers": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -760,6 +795,35 @@
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "dev": true,
             "requires": {
+                "babel-runtime": "6.26.0"
+            }
+        },
+        "babel-plugin-syntax-async-functions": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+            "dev": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+            "dev": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+            "dev": true
+        },
+        "babel-plugin-transform-async-to-generator": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+            "dev": true,
+            "requires": {
+                "babel-helper-remap-async-to-generator": "6.24.1",
+                "babel-plugin-syntax-async-functions": "6.13.0",
                 "babel-runtime": "6.26.0"
             }
         },
@@ -997,6 +1061,17 @@
                 "regexpu-core": "2.0.0"
             }
         },
+        "babel-plugin-transform-exponentiation-operator": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+            "dev": true,
+            "requires": {
+                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+                "babel-runtime": "6.26.0"
+            }
+        },
         "babel-plugin-transform-regenerator": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -1016,13 +1091,15 @@
                 "babel-types": "6.26.0"
             }
         },
-        "babel-preset-es2015": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-            "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+        "babel-preset-env": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+            "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
             "dev": true,
             "requires": {
                 "babel-plugin-check-es2015-constants": "6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+                "babel-plugin-transform-async-to-generator": "6.24.1",
                 "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
                 "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
                 "babel-plugin-transform-es2015-block-scoping": "6.26.0",
@@ -1045,7 +1122,19 @@
                 "babel-plugin-transform-es2015-template-literals": "6.22.0",
                 "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
                 "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0"
+                "babel-plugin-transform-exponentiation-operator": "6.24.1",
+                "babel-plugin-transform-regenerator": "6.26.0",
+                "browserslist": "2.11.3",
+                "invariant": "2.2.2",
+                "semver": "5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "dev": true
+                }
             }
         },
         "babel-register": {
@@ -1426,6 +1515,16 @@
                 "pako": "1.0.6"
             }
         },
+        "browserslist": {
+            "version": "2.11.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+            "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "1.0.30000792",
+                "electron-to-chromium": "1.3.31"
+            }
+        },
         "buffer": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
@@ -1511,6 +1610,12 @@
                 "camelcase": "2.1.1",
                 "map-obj": "1.0.1"
             }
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000792",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+            "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI=",
+            "dev": true
         },
         "caseless": {
             "version": "0.11.0",
@@ -2446,6 +2551,12 @@
                 "jsbn": "0.1.1"
             }
         },
+        "electron-to-chromium": {
+            "version": "1.3.31",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+            "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+            "dev": true
+        },
         "elliptic": {
             "version": "6.4.0",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -2999,13 +3110,15 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+                    "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
                     "dev": true,
                     "optional": true
                 },
                 "ajv": {
                     "version": "4.11.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3015,18 +3128,21 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "dev": true
                 },
                 "aproba": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+                    "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
                     "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                    "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3036,42 +3152,49 @@
                 },
                 "asn1": {
                     "version": "0.2.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                     "dev": true,
                     "optional": true
                 },
                 "assert-plus": {
                     "version": "0.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                     "dev": true,
                     "optional": true
                 },
                 "asynckit": {
                     "version": "0.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                     "dev": true,
                     "optional": true
                 },
                 "aws-sign2": {
                     "version": "0.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                     "dev": true,
                     "optional": true
                 },
                 "aws4": {
                     "version": "1.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                    "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                     "dev": true,
                     "optional": true
                 },
                 "balanced-match": {
                     "version": "0.4.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                     "dev": true
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                    "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3080,7 +3203,8 @@
                 },
                 "block-stream": {
                     "version": "0.0.9",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                    "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                     "dev": true,
                     "requires": {
                         "inherits": "2.0.3"
@@ -3088,7 +3212,8 @@
                 },
                 "boom": {
                     "version": "2.10.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                    "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                     "dev": true,
                     "requires": {
                         "hoek": "2.16.3"
@@ -3096,7 +3221,8 @@
                 },
                 "brace-expansion": {
                     "version": "1.1.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                    "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                     "dev": true,
                     "requires": {
                         "balanced-match": "0.4.2",
@@ -3105,29 +3231,34 @@
                 },
                 "buffer-shims": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                    "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
                     "dev": true
                 },
                 "caseless": {
                     "version": "0.12.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                     "dev": true,
                     "optional": true
                 },
                 "co": {
                     "version": "4.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                     "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "dev": true
                 },
                 "combined-stream": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                    "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                     "dev": true,
                     "requires": {
                         "delayed-stream": "1.0.0"
@@ -3135,22 +3266,26 @@
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                     "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "dev": true
                 },
                 "cryptiles": {
                     "version": "2.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                    "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                     "dev": true,
                     "requires": {
                         "boom": "2.10.1"
@@ -3158,7 +3293,8 @@
                 },
                 "dashdash": {
                     "version": "1.14.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3167,7 +3303,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -3175,7 +3312,8 @@
                 },
                 "debug": {
                     "version": "2.6.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3184,30 +3322,35 @@
                 },
                 "deep-extend": {
                     "version": "0.4.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                    "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                     "dev": true,
                     "optional": true
                 },
                 "delayed-stream": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                     "dev": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+                    "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
                     "dev": true,
                     "optional": true
                 },
                 "ecc-jsbn": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3216,24 +3359,28 @@
                 },
                 "extend": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                    "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                     "dev": true,
                     "optional": true
                 },
                 "extsprintf": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                    "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                     "dev": true
                 },
                 "forever-agent": {
                     "version": "0.6.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                     "dev": true,
                     "optional": true
                 },
                 "form-data": {
                     "version": "2.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3244,12 +3391,14 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "dev": true
                 },
                 "fstream": {
                     "version": "1.0.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                    "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
@@ -3260,7 +3409,8 @@
                 },
                 "fstream-ignore": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                    "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3271,7 +3421,8 @@
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3287,7 +3438,8 @@
                 },
                 "getpass": {
                     "version": "0.1.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3296,7 +3448,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -3304,7 +3457,8 @@
                 },
                 "glob": {
                     "version": "7.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "1.0.0",
@@ -3317,18 +3471,21 @@
                 },
                 "graceful-fs": {
                     "version": "4.1.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                     "dev": true
                 },
                 "har-schema": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                     "dev": true,
                     "optional": true
                 },
                 "har-validator": {
                     "version": "4.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3338,13 +3495,15 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "dev": true,
                     "optional": true
                 },
                 "hawk": {
                     "version": "3.1.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                    "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                     "dev": true,
                     "requires": {
                         "boom": "2.10.1",
@@ -3355,12 +3514,14 @@
                 },
                 "hoek": {
                     "version": "2.16.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                     "dev": true
                 },
                 "http-signature": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3371,7 +3532,8 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "dev": true,
                     "requires": {
                         "once": "1.4.0",
@@ -3380,18 +3542,21 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                     "dev": true
                 },
                 "ini": {
                     "version": "1.3.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                    "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
                     "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
                         "number-is-nan": "1.0.1"
@@ -3399,24 +3564,28 @@
                 },
                 "is-typedarray": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                     "dev": true,
                     "optional": true
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 },
                 "isstream": {
                     "version": "0.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                     "dev": true,
                     "optional": true
                 },
                 "jodid25519": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                    "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3425,19 +3594,22 @@
                 },
                 "jsbn": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                     "dev": true,
                     "optional": true
                 },
                 "json-schema": {
                     "version": "0.2.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                     "dev": true,
                     "optional": true
                 },
                 "json-stable-stringify": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                    "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3446,19 +3618,22 @@
                 },
                 "json-stringify-safe": {
                     "version": "5.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                     "dev": true,
                     "optional": true
                 },
                 "jsonify": {
                     "version": "0.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                    "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                     "dev": true,
                     "optional": true
                 },
                 "jsprim": {
                     "version": "1.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                    "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3470,7 +3645,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -3478,12 +3654,14 @@
                 },
                 "mime-db": {
                     "version": "1.27.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                    "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                     "dev": true
                 },
                 "mime-types": {
                     "version": "2.1.15",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                    "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                     "dev": true,
                     "requires": {
                         "mime-db": "1.27.0"
@@ -3491,7 +3669,8 @@
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "1.1.7"
@@ -3499,12 +3678,14 @@
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -3512,13 +3693,15 @@
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true,
                     "optional": true
                 },
                 "node-pre-gyp": {
                     "version": "0.6.39",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+                    "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3537,7 +3720,8 @@
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3547,7 +3731,8 @@
                 },
                 "npmlog": {
                     "version": "4.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+                    "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3559,24 +3744,28 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "dev": true
                 },
                 "oauth-sign": {
                     "version": "0.8.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                     "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
                     "requires": {
                         "wrappy": "1.0.2"
@@ -3584,19 +3773,22 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                    "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3606,35 +3798,41 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "dev": true
                 },
                 "performance-now": {
                     "version": "0.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "1.0.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                     "dev": true
                 },
                 "punycode": {
                     "version": "1.4.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                     "dev": true,
                     "optional": true
                 },
                 "qs": {
                     "version": "6.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                    "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3646,7 +3844,8 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "dev": true,
                             "optional": true
                         }
@@ -3654,7 +3853,8 @@
                 },
                 "readable-stream": {
                     "version": "2.2.9",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                    "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
                     "dev": true,
                     "requires": {
                         "buffer-shims": "1.0.0",
@@ -3668,7 +3868,8 @@
                 },
                 "request": {
                     "version": "2.81.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3698,7 +3899,8 @@
                 },
                 "rimraf": {
                     "version": "2.6.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                    "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
                     "dev": true,
                     "requires": {
                         "glob": "7.1.2"
@@ -3706,30 +3908,35 @@
                 },
                 "safe-buffer": {
                     "version": "5.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                    "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
                     "dev": true
                 },
                 "semver": {
                     "version": "5.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "dev": true,
                     "optional": true
                 },
                 "sntp": {
                     "version": "1.0.9",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                    "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                     "dev": true,
                     "requires": {
                         "hoek": "2.16.3"
@@ -3737,7 +3944,8 @@
                 },
                 "sshpk": {
                     "version": "1.13.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                    "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3754,7 +3962,8 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -3762,7 +3971,8 @@
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
                         "code-point-at": "1.1.0",
@@ -3772,7 +3982,8 @@
                 },
                 "string_decoder": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+                    "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                     "dev": true,
                     "requires": {
                         "safe-buffer": "5.0.1"
@@ -3780,13 +3991,15 @@
                 },
                 "stringstream": {
                     "version": "0.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                    "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                     "dev": true,
                     "optional": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
                         "ansi-regex": "2.1.1"
@@ -3794,13 +4007,15 @@
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "2.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                     "dev": true,
                     "requires": {
                         "block-stream": "0.0.9",
@@ -3810,7 +4025,8 @@
                 },
                 "tar-pack": {
                     "version": "3.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+                    "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3826,7 +4042,8 @@
                 },
                 "tough-cookie": {
                     "version": "2.3.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                    "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3835,7 +4052,8 @@
                 },
                 "tunnel-agent": {
                     "version": "0.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3844,30 +4062,35 @@
                 },
                 "tweetnacl": {
                     "version": "0.14.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                     "dev": true,
                     "optional": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                    "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
                     "dev": true,
                     "optional": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "dev": true
                 },
                 "uuid": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                    "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
                     "dev": true,
                     "optional": true
                 },
                 "verror": {
                     "version": "1.3.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                    "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3876,7 +4099,8 @@
                 },
                 "wide-align": {
                     "version": "1.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                    "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3885,7 +4109,8 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "dev": true
                 }
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     },
     "devDependencies": {
         "babel-core": "6.26.0",
-        "babel-preset-es2015": "6.24.1",
+        "babel-preset-env": "1.6.1",
         "babelify": "8.0.0",
         "browserify": "15.2.0",
         "config": "1.29.2",

--- a/frontend/source/javascript/components/accounts/add.js
+++ b/frontend/source/javascript/components/accounts/add.js
@@ -41,7 +41,7 @@ function AccountAddController(Utils) {
         if (vm.account.contacts.length === 0) {
             Utils.toast('Contacts cannot be empty', 'error');
         } else {
-	    const accountInfo = Object.assign({}, vm.account, {enabled: vm.account.enabled ? 1 : 0});
+            const accountInfo = Object.assign({}, vm.account, {enabled: vm.account.enabled ? 1 : 0});
             vm.onAccountCreate(accountInfo, onAddSuccess, onAddFailure);
         }
     }


### PR DESCRIPTION
* Fix jslint warnings about whitespace character
* Change to use babel-preset-env instead of specific preset, as older presets have been deprecated in favor of babel-preset-env