### PR TITLE
Fixing prod JS build

### DIFF
--- a/frontend/gulp/tasks/build/javascript.prod.js
+++ b/frontend/gulp/tasks/build/javascript.prod.js
@@ -18,11 +18,11 @@ const deps = Object.keys(pkg.dependencies);
 gulp.task('build.javascript.prod', function () {
     return browserify(config.app)
         .transform("babelify", {
-            presets: ['env', {
+            presets: [['env', {
                 "targets": {
                     "chrome": "60"
                 }
-            }]
+            }]]
         })
         .external(deps)
         .bundle()


### PR DESCRIPTION
This fixes a syntax error in the production javascript build task for gulp