### PR TITLE
Fixing a permissions issue on the settings folder

### DIFF
--- a/packer/scripts/install.sh
+++ b/packer/scripts/install.sh
@@ -41,7 +41,7 @@ install_backend() {
 
         # Create log folders for the application and allow the backend user to write to them
         mkdir -p logs
-        chown -R www-data:www-data logs
+        chown -R www-data:www-data logs settings
     )
 }
 


### PR DESCRIPTION
There's an issue where the `settings` folder weren't chown'd to the web user, making the api server unable to start up due to lack of permissions to write the regions file.