### PR TITLE
Fixed typo in the scheduler command config

### DIFF
--- a/packer/files/supervisor.conf
+++ b/packer/files/supervisor.conf
@@ -15,7 +15,7 @@ autostart=true
 autorestart=true
 directory=APP_BACKEND_BASE_PATH
 environment=PYTHONPATH='APP_BACKEND_BASE_PATH',INQUISITOR_SETTINGS="APP_BACKEND_BASE_PATH/settings/production.py"
-command=APP_PYENV_PATH/bin/cloud-inquisitorscheduler
+command=APP_PYENV_PATH/bin/cloud-inquisitor scheduler
 
 [program:cinq-worker]
 process_name=%(program_name)s_%(process_num)d


### PR DESCRIPTION
Scheduler wasn't starting due a to missing "space" in the command.