### PR TITLE
Import SAML metadata configuration

### DIFF
--- a/backend/cloud_inquisitor/plugins/commands/saml.py
+++ b/backend/cloud_inquisitor/plugins/commands/saml.py
@@ -1,0 +1,84 @@
+import xml.etree.ElementTree as etree
+
+from flask_script import Option
+from pkg_resources import iter_entry_points
+
+from cloud_inquisitor.constants import PLUGIN_NAMESPACES
+from cloud_inquisitor.config import dbconfig, DBCString
+from cloud_inquisitor.plugins.commands import BaseCommand
+
+
+class ImportSAML(BaseCommand):
+    """Imports a SAML metadata.xml file and populates the SAML configuration"""
+    name = 'ImportSAML'
+    option_list = (
+        Option(
+            '-m', '--metadata-file',
+            dest='metadata',
+            type=str,
+            help='Path to the metadata.xml file',
+            required=True
+        ),
+        Option(
+            '-f', '--fqdn',
+            dest='fqdn',
+            type=str,
+            help='Domain name of the instance',
+            required=True
+        )
+    )
+
+    def run(self, **kwargs):
+        config_namespace = None
+        for ns in PLUGIN_NAMESPACES['auth']:
+            for ep in iter_entry_points(ns):
+                if ep.module_name == 'cinq_auth_onelogin_saml':
+                    cls = ep.load()
+                    config_namespace = cls.ns
+                    break
+            else:
+                self.log.error('The SAML authentication plugin is not installed')
+                return
+
+        try:
+            ns = {
+                'ds': 'http://www.w3.org/2000/09/xmldsig#',
+                'saml': 'urn:oasis:names:tc:SAML:2.0:metadata'
+            }
+
+            xml = etree.parse(kwargs['metadata'])
+            root = xml.getroot()
+
+            idp_entity_id = root.attrib['entityID']
+            idp_cert = root.find('.//ds:X509Certificate', ns).text
+            idp_sls = root.find('.//saml:SingleLogoutService', ns).attrib['Location']
+            idp_ssos = root.find(
+                './/saml:SingleSignOnService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"]',
+                ns
+            ).attrib['Location']
+
+            sp_acs = 'https://{}/saml/login/consumer'.format(kwargs['fqdn'])
+            sp_sls = 'https://{}/saml/logout/consumer'.format(kwargs['fqdn'])
+            sp_entity_id = kwargs['fqdn']
+
+            dbconfig.set(config_namespace, 'idp_entity_id', DBCString(idp_entity_id))
+            dbconfig.set(config_namespace, 'idp_sls', DBCString(idp_sls))
+            dbconfig.set(config_namespace, 'idp_ssos', DBCString(idp_ssos))
+            dbconfig.set(config_namespace, 'idp_x509cert', DBCString(idp_cert.replace('\n', '')))
+            dbconfig.set(config_namespace, 'sp_entity_id', DBCString(sp_entity_id))
+            dbconfig.set(config_namespace, 'sp_acs', DBCString(sp_acs))
+            dbconfig.set(config_namespace, 'sp_sls', DBCString(sp_sls))
+
+            self.log.info('Updated SAML configuration from {}'.format(kwargs['metadata']))
+
+        except OSError as ex:
+            self.log.error('Unable to load metadata file {}: {}'.format(kwargs['metadata'], ex))
+            return 1
+
+        except etree.ParseError as ex:
+            self.log.error('Failed reading metadata XML file: {}'.format(ex))
+            return 2
+
+        except Exception as ex:
+            self.log.error('Error while updating configuration: {}'.format(ex))
+            return 3

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
             'api_server = cloud_inquisitor.plugins.commands.apiserver:APIServer',
             'list_plugins = cloud_inquisitor.plugins.commands.plugins:ListPlugins',
             'scheduler = cloud_inquisitor.plugins.commands.scheduler:Scheduler',
+            'import-saml = cloud_inquisitor.plugins.commands.saml:ImportSAML',
             'worker = cloud_inquisitor.plugins.commands.scheduler:Worker',
             'userdata = cloud_inquisitor.plugins.commands.userdata:UserData',
             'setup = cloud_inquisitor.plugins.commands.setup:Setup',


### PR DESCRIPTION
Adding command to import metadata.xml for SAML configurations. This provides a new CLI command to import the metadata.xml containing information about SAML endpoints.

Usage: `cloud-inquisitor import-saml --metadata-file /path/to/metadata.xml --domain inquisitor.domain.tld`

The --domain is required to correctly set the consumer URLs for the SAML responses.