### PR TITLE
Silence parso debug logging in ipython

### DIFF
--- a/backend/settings/logging.json
+++ b/backend/settings/logging.json
@@ -107,6 +107,10 @@
                 "database"
             ]
         },
+        "parso": {
+            "level": "WARNING",
+            "propagate": "false"
+        },
         "git": {
             "level": 100,
             "propagate": "false"

--- a/packer/files/logging.json
+++ b/packer/files/logging.json
@@ -106,6 +106,10 @@
                 "database"
             ]
         },
+        "parso": {
+            "level": "WARNING",
+            "propagate": "false"
+        },
         "git": {
             "level": 100,
             "propagate": "false"


### PR DESCRIPTION
When using ipython (`cloud-inquisitor shell`) the parso plugin currently spams a log of debug information into the terminal if Cloud Inquisitor is running in DEBUG mode. Change the default logging.json to only log warnings or higher from parso