### PR TITLE
Add new get_local_aws_session function

### DIFF
--- a/backend/cloud_inquisitor/plugins/commands/userdata.py
+++ b/backend/cloud_inquisitor/plugins/commands/userdata.py
@@ -3,10 +3,9 @@ import os
 from base64 import b64encode, b64decode
 from gzip import zlib
 
-import boto3.session
 from flask_script import Option
 
-from cloud_inquisitor import get_aws_session, app_config
+from cloud_inquisitor import get_aws_session, app_config, get_local_aws_session
 from cloud_inquisitor.plugins.commands import BaseCommand
 from cloud_inquisitor.schema import Account
 
@@ -24,8 +23,6 @@ class UserData(BaseCommand):
                help='Region the KMS key is located in'),
         Option('-d', '--data', dest='data', type=str, required=True,
                help='String formatted data to operate on. If prefixed with @ it will be treated as a file to be read'),
-        Option('-a', '--access-key', dest='access_key', type=str, default=None, help='AWS API Access key id'),
-        Option('-s', '--secret-key', dest='secret_key', type=str, default=None, help='AWS API Secret Access Key'),
         Option('-o', '--output-file', dest='output_file', type=str, help='Optional. Output file for the data'),
         Option('-e', '--encode-output', dest='encode_output', action='store_true', default=False,
                help='Base 64 encode the output'),
@@ -37,8 +34,6 @@ class UserData(BaseCommand):
         self.kwargs = kwargs
         try:
             key_id = self.kwargs['key_id']
-            access_key = self.kwargs['access_key'] or app_config.aws_api.access_key
-            secret_key = self.kwargs['secret_key'] or app_config.aws_api.secret_key
 
             if self.kwargs['data'].startswith('@'):
                 path = self.kwargs['data'][1:]
@@ -53,12 +48,11 @@ class UserData(BaseCommand):
             else:
                 data = kwargs['data']
 
-            if access_key and secret_key:
-                session = boto3.session.Session(access_key, secret_key)
-            else:
+            session = get_local_aws_session()
+            if session.get_credentials().method != 'iam-role':
                 kms_account_name = app_config.kms_account_name
                 if not kms_account_name:
-                    print('you must set the KMS_ACCOUNT_NAME setting in your configuration file to the name of the '
+                    print('you must set the kms_account_name setting in your configuration file to the name of the '
                           'account that is able to decrypt the user data')
                     return
                 acct = Account.get(kms_account_name)

--- a/backend/cloud_inquisitor/plugins/notifiers/email.py
+++ b/backend/cloud_inquisitor/plugins/notifiers/email.py
@@ -5,9 +5,7 @@ from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-import boto3.session
-
-from cloud_inquisitor import app_config
+from cloud_inquisitor import get_local_aws_session
 from cloud_inquisitor.config import dbconfig, ConfigOption
 from cloud_inquisitor.constants import NS_EMAIL
 from cloud_inquisitor.database import db
@@ -115,16 +113,10 @@ def __send_ses_email(sender, recipients, subject, html_body, text_body):
     Returns:
         `None`
     """
-    access_key = app_config.aws_api.access_key
-    secret_key = app_config.aws_api.secret_key
     source_arn = dbconfig.get('source_arn', NS_EMAIL)
     return_arn = dbconfig.get('return_path_arn', NS_EMAIL)
 
-    if access_key and secret_key:
-        session = boto3.session.Session(access_key, secret_key)
-    else:
-        session = boto3.session.Session()
-
+    session = get_local_aws_session()
     ses = session.client('ses', region_name=dbconfig.get('ses_region', NS_EMAIL, 'us-west-2'))
 
     body = {}


### PR DESCRIPTION
As the `get_aws_session` only works to get a session for a remote account via. `sts:AssumeRole`, we need a way to easily get a session for the local instance (typically for the instance itself). This is needed in a couple of scenarios, for example for the SQS scheduler and the SES email sending, where we need to run under the instance profile instead of the assume auditing role.

This PR adds a new function `get_local_aws_session` which handles setting up a boto3 session from either the configuration file settings or using boto3's builtin resolution for finding AWS API credentials (https://boto3.readthedocs.io/en/latest/guide/configuration.html)

If needed you can do the following to detect if the credentials are from an instance role, or from a configuration file / environment variables:

```python
from cloud_inquisitor import get_local_aws_session
session = get_local_aws_session()

if session.get_credentials().method == 'iam-role':
    print('Credentials were from an instance role')
else:
    print('Configuration file or environment based credentials')
```