### PR TITLE
Incorrectly tried to add two datetime values

### DIFF
--- a/backend/cloud_inquisitor/plugins/types/issues.py
+++ b/backend/cloud_inquisitor/plugins/types/issues.py
@@ -347,7 +347,7 @@ class RequiredTagsIssue(BaseIssue):
         if updated:
             now = datetime.now()
             self.set_property('last_change', now)
-            self.set_property('next_change', now + data['next_change'])
+            self.set_property('next_change', data['next_change'])
 
         return updated
 


### PR DESCRIPTION
The auditor is responsible for passing in a datetime object, not a timedelta, so we dont need to do the arithmetic in the update function but simply just use the value being passed in.