### PR TITLE
Implement missing Account.delete method

### DIFF
--- a/backend/cloud_inquisitor/schema/base.py
+++ b/backend/cloud_inquisitor/schema/base.py
@@ -172,6 +172,7 @@ class Account(Model, BaseModelMixin):
         Returns:
             `None`
         """
+        self.log.info('Deleting account {}'.format(self.account_name))
         db.session.delete(self)
         if auto_commit:
             db.session.commit()

--- a/backend/cloud_inquisitor/schema/base.py
+++ b/backend/cloud_inquisitor/schema/base.py
@@ -163,6 +163,19 @@ class Account(Model, BaseModelMixin):
 
         return False
 
+    def delete(self, auto_commit=True):
+        """Delete the account and all of its resources from the database
+
+        Args:
+             auto_commit (`bool`): Automatically commit the change to the database. Default: `True`
+
+        Returns:
+            `None`
+        """
+        db.session.delete(self)
+        if auto_commit:
+            db.session.commit()
+
     @classmethod
     def get(cls, account):
         """Return an Account object by name


### PR DESCRIPTION
The `delete` method for account objects had not been implemented, which made it impossible to remove an account from the system without manually removing it from the database.