### PR TITLE
fix(sqlservice): Upgrade SQLService to allow use of pre-ping

### DIFF
--- a/backend/cloud_inquisitor/database.py
+++ b/backend/cloud_inquisitor/database.py
@@ -7,7 +7,9 @@ Model = declarative_base()
 
 def get_db_connection():
     return SQLClient({
-        'SQL_DATABASE_URI': app_config.database_uri
+        'SQL_DATABASE_URI': app_config.database_uri,
+        'SQL_POOL_RECYCLE': 3600,
+        'SQL_POOL_PRE_PING': True
     }, model_class=Model)
 
 

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -125,7 +125,7 @@ setuptools.setup(
         'rainbow-logging-handler~=2.2',
         'requests~=2.14',
         'slackclient~=1.0',
-        'sqlservice~=0.14.2',
+        'sqlservice~=0.20',
     ],
 
     # Metadata


### PR DESCRIPTION
Due to connection pooling issues with gunicorn, at times the database
connections time out, which causes an 'MySQL server has gone away'
errors for the clients.

Firstly, we set the connection pool recycle time, but more importantly
we are also enabling the pre-ping functionality. This causes SQLAlchemy
to test each connection are they are being activated from the pool, and
in the cause of an error, it will attempt to reconnect to the DB server
before returning the connection