### PR TITLE
feat(auditlog): Update auditlog to support remotely logging actions

### DIFF
--- a/backend/cloud_inquisitor/data/templates/syslog_format.json
+++ b/backend/cloud_inquisitor/data/templates/syslog_format.json
@@ -1,0 +1,14 @@
+{
+    "jsonEvent": "{{ event_type }}",
+    "Event": {
+        "meta": {
+            "host": "{{ host }}"
+        },
+        "record": {
+            "level": "%(levelname)s",
+            "time": "%(asctime)s",
+            "name": "%(name)s",
+            "message": "%(message)s"
+        }
+    }
+}

--- a/backend/cloud_inquisitor/plugins/notifiers/email.py
+++ b/backend/cloud_inquisitor/plugins/notifiers/email.py
@@ -13,8 +13,7 @@ from cloud_inquisitor.database import db
 from cloud_inquisitor.exceptions import EmailSendError
 from cloud_inquisitor.plugins.notifiers import BaseNotifier
 from cloud_inquisitor.schema import Email
-from cloud_inquisitor.utils import send_notification, NotificationContact
-from cloud_inquisitor.wrappers import deprecated
+from cloud_inquisitor.utils import send_notification, NotificationContact, deprecated
 
 
 class EmailNotifier(BaseNotifier):

--- a/backend/cloud_inquisitor/plugins/notifiers/slack.py
+++ b/backend/cloud_inquisitor/plugins/notifiers/slack.py
@@ -6,8 +6,7 @@ from cloud_inquisitor.config import dbconfig, ConfigOption
 from cloud_inquisitor.constants import NS_SLACK, RGX_EMAIL_VALIDATION_PATTERN
 from cloud_inquisitor.exceptions import SlackError
 from cloud_inquisitor.plugins.notifiers import BaseNotifier
-from cloud_inquisitor.utils import NotificationContact, send_notification
-from cloud_inquisitor.wrappers import deprecated
+from cloud_inquisitor.utils import NotificationContact, send_notification, deprecated
 
 
 class SlackNotifier(BaseNotifier):

--- a/backend/cloud_inquisitor/plugins/views/emails.py
+++ b/backend/cloud_inquisitor/plugins/views/emails.py
@@ -4,8 +4,9 @@ from sqlalchemy import desc, func, distinct
 from cloud_inquisitor.constants import ROLE_ADMIN, HTTP
 from cloud_inquisitor.database import db
 from cloud_inquisitor.exceptions import EmailSendError
+from cloud_inquisitor.log import auditlog
 from cloud_inquisitor.plugins import BaseView
-from cloud_inquisitor.schema import Email, AuditLog
+from cloud_inquisitor.schema import Email
 from cloud_inquisitor.utils import MenuItem, send_notification, NotificationContact
 from cloud_inquisitor.wrappers import check_auth, rollback
 
@@ -96,7 +97,7 @@ class EmailGet(BaseView):
                 body_text=email.message_text
             )
 
-            AuditLog.log('email.resend', session['user'].username, {'emailId': emailId})
+            auditlog(event='email.resend', actor=session['user'].username, data={'emailId': emailId})
             return self.make_response('Email resent successfully')
 
         except EmailSendError as ex:

--- a/backend/cloud_inquisitor/utils.py
+++ b/backend/cloud_inquisitor/utils.py
@@ -12,6 +12,7 @@ from base64 import b64decode
 from collections import namedtuple
 from copy import deepcopy
 from datetime import datetime
+from functools import wraps
 
 import boto3.session
 import jwt
@@ -553,3 +554,26 @@ def send_notification(*, subsystem, recipients, subject, body_html, body_text):
                         recipient.type,
                         recipient.value
                     ))
+
+
+def deprecated(msg):
+    """Marks a function / method as deprecated.
+
+    Takes one argument, a message to be logged with information on future usage of the function or alternative methods
+    to call.
+
+    Args:
+        msg (str): Deprecation message to be logged
+
+    Returns:
+        `callable`
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            logging.getLogger(__name__).warning(msg)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/packer/files/logging.json
+++ b/packer/files/logging.json
@@ -55,7 +55,7 @@
             "class": "cloud_inquisitor.log.DBLogger",
             "min_level": "WARNING"
         },
-        "pipeline": {
+        "syslog": {
             "class": "cloud_inquisitor.log.SyslogPipelineHandler",
             "formatter": "syslog",
             "filters": ["standard"]
@@ -76,7 +76,7 @@
             "handlers": [
                 "console",
                 "database",
-                "pipeline"
+                "syslog"
             ]
         },
         "apscheduler": {


### PR DESCRIPTION
Instead of just saving audit log information to the database, we now have the ability to also send the logs to a remote syslog server using a standard python logging object.

Deprecated the use of `AuditLog.log` from `cloud_inquisitor.schema.base` in favor of `auditlog` from `cloud_inquisitor.log`. Signature is nearly identical, except arguments are now keyword only.

Example usage:
```
from cloud_inquisitor.log import auditlog

auditlog(
    event='module.action',
    actor='username',
    data={
        'some': 'datastructure here'
    }
)
```