### PR TITLE
perf(issue_properties): Add foreign keys to issue_properties

### DIFF
--- a/backend/cloud_inquisitor/data/migrations/versions/1edcdfbc7780_issueproperty_foreign_key.py
+++ b/backend/cloud_inquisitor/data/migrations/versions/1edcdfbc7780_issueproperty_foreign_key.py
@@ -1,0 +1,25 @@
+"""IssueProperty foreign key
+
+Revision ID: 1edcdfbc7780
+Revises: a2e49567641a
+Create Date: 2018-05-24 12:13:53.753193
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1edcdfbc7780'
+down_revision = 'a2e49567641a'
+
+
+def upgrade():
+    # Delete existing orphaned entries into the issue_properties tables
+    op.execute('DELETE FROM issue_properties WHERE issue_id NOT IN (SELECT issue_id FROM issues)')
+    op.create_foreign_key('fk_issue_properties_issue_id', 'issue_properties', 'issues', ['issue_id'], ['issue_id'], ondelete='CASCADE')
+
+
+def downgrade():
+    op.drop_constraint('fk_issue_properties_issue_id', 'issue_properties', type_='foreignkey')

--- a/backend/cloud_inquisitor/schema/issues.py
+++ b/backend/cloud_inquisitor/schema/issues.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, ForeignKey
 from sqlalchemy.dialects.mysql import INTEGER as Integer, JSON
 from sqlalchemy.orm import foreign, relationship
 
@@ -59,7 +59,13 @@ class IssueProperty(Model, BaseModelMixin):
     __tablename__ = 'issue_properties'
 
     property_id = Column(Integer(unsigned=True), primary_key=True, autoincrement=True)
-    issue_id = Column(String(256), nullable=False, primary_key=True, index=True)
+    issue_id = Column(
+        String(256),
+        ForeignKey('issues.issue_id', name='fk_issue_properties_issue_id', ondelete='CASCADE'),
+        nullable=False,
+        primary_key=True,
+        index=True
+    )
     name = Column(String(50), nullable=False, index=True)
     value = Column(JSON, nullable=False)
 


### PR DESCRIPTION
Added a foreign key constraint between issue_properties.issue_id -> issues.issue_id to be able to cascade deletes when an issue is removed, cleaning up orphaned issue_properties entries.