### PR TITLE
revert(add_account): Reverting add_account change for Account view

### DIFF
--- a/backend/cloud_inquisitor/plugins/views/accounts.py
+++ b/backend/cloud_inquisitor/plugins/views/accounts.py
@@ -24,34 +24,6 @@ def validate_contacts(contacts):
             raise Exception('Unsupported notification type: {}'.format(contact['type']))
 
 
-def add_account(
-        account_name, account_number, account_contacts,
-        is_enabled=True, ad_groupbase=None, required_groups=None,
-        update_account_id=None, auto_commit=True
-):
-    """
-    Add or update an account.
-    if update_account_id is None, we add a new account; Otherwise we update the account with update_account_id
-    """
-    if update_account_id:
-        acct = db.Account.find_one(Account.account_id == update_account_id)
-    else:
-        acct = Account(
-            account_name,
-            account_number,
-            account_contacts,
-            is_enabled,
-            ad_groupbase
-        )
-    acct.required_groups = required_groups if required_groups else {}
-
-    db.session.add(acct)
-    if auto_commit:
-        db.session.commit()
-
-    return acct
-
-
 class AccountList(BaseView):
     URLS = ['/api/v1/account']
     MENU_ITEMS = [
@@ -114,14 +86,16 @@ class AccountList(BaseView):
         if db.Account.filter_by(account_name=args['accountName']).count() > 0:
             raise Exception('Account already exists')
 
-        acct = add_account(
-            account_name=args['accountName'],
-            account_number=args['accountNumber'].zfill(12),
-            account_contacts=args['contacts'],
-            is_enabled=args['enabled'],
-            ad_groupbase=args['adGroupBase'],
-            required_groups=json.dumps(args['requiredGroups'])
+        acct = Account(
+            args['accountName'],
+            args['accountNumber'].zfill(12),
+            args['contacts'],
+            args['enabled'],
+            args['adGroupBase']
         )
+        acct.required_groups = json.dumps(args['requiredGroups'])
+        db.session.add(acct)
+        db.session.commit()
 
         # Add the newly created account to the session so we can see it right away
         session['accounts'].append(acct.account_id)
@@ -168,15 +142,16 @@ class AccountDetail(BaseView):
         if not args['contacts']:
             raise Exception('You must provide at least one contact')
 
-        acct = add_account(
-            account_name=args['accountName'],
-            account_number=args['accountNumber'].zfill(12),
-            account_contacts=args['contacts'],
-            is_enabled=args['enabled'],
-            ad_groupbase=args['adGroupBase'],
-            required_groups=json.dumps(args['requiredGroups']),
-            update_account_id=accountId
-        )
+        acct = db.Account.find_one(Account.account_id == accountId)
+        acct.account_name = args['accountName']
+        acct.account_number = args['accountNumber'].zfill(12)
+        acct.contacts = args['contacts']
+        acct.enabled = args['enabled']
+        acct.required_roles = args['requiredRoles']
+        acct.ad_group_base = args['adGroupBase']
+
+        db.session.add(acct)
+        db.session.commit()
         auditlog(event='account.update', actor=session['user'].username, data=args)
 
         return self.make_response({'message': 'Object updated', 'account': acct.to_json(is_admin=True)})
@@ -232,16 +207,17 @@ class AccountImportExport(BaseView):
                         HTTP.BAD_REQUEST
                     )
 
-                add_account(
-                    account_name=args['accountName'],
-                    account_number=args['accountNumber'].zfill(12),
-                    account_contacts=args['contacts'],
-                    is_enabled=args['enabled'],
-                    ad_groupbase=args['adGroupBase'],
-                    required_groups=json.dumps(args['requiredGroups']),
-                    update_account_id=None if not acct else acct.account_id,
-                    auto_commit=False
-                )
+                if not acct:
+                    acct = Account()
+
+                acct.account_number = acctData['accountNumber']
+                acct.contacts = acctData['contacts']
+                acct.account_type = acctData['accountType']
+                acct.ad_group_base = acctData['adGroupBase']
+                acct.enabled = acctData['enabled']
+                acct.required_roles = acctData['requiredRoles']
+
+                db.session.add(acct)
 
             db.session.commit()
             auditlog(event='account.import', actor=session['user'].username, data={})

--- a/backend/tests/service/service.py
+++ b/backend/tests/service/service.py
@@ -94,24 +94,22 @@ class CinqTestService(object):
 
     ''' DB related routines '''
 
-    def add_test_account(self, **kwargs):
-        self.test_account = Account()
-        self.test_account.account_name = kwargs.get('account_name', CINQ_TEST_ACCOUNT_NAME)
-        self.test_account.account_number = kwargs.get('account_number', CINQ_TEST_ACCOUNT_NO)
-        self.test_account.contacts = kwargs.get(
-            'contacts',
-            [{'type': 'email', 'value': dbconfig.get('test_email', NS_CINQ_TEST)}]
-        )
-        self.test_account.enabled = kwargs.get('is_enabled', 1)
-        self.test_account.ad_group_base = kwargs.get('ad_groupbase', None)
-        self.test_account.required_roles = kwargs.get('required_groups', [])
+    def add_test_account(self, required_roles=None, **kwargs):
+        self.test_account = Account(**kwargs)
+        self.test_account.required_roles = required_roles if required_roles else []
 
         db.session.add(self.test_account)
         db.session.commit()
 
     def reset_db_data(self):
         empty_tables(Account, Issue, Resource)
-        self.add_test_account()
+        self.add_test_account(
+            name=CINQ_TEST_ACCOUNT_NAME,
+            account_number=CINQ_TEST_ACCOUNT_NO,
+            contacts=[{'type': 'email', 'value': dbconfig.get('test_email', NS_CINQ_TEST)}],
+            enabled=True,
+            ad_group_base=None
+        )
 
     def reset_db_config(self):
         empty_tables(ConfigItem)


### PR DESCRIPTION
A previous PR, which added test frameworks added a new function to create accounts to the Accounts view. Removing this function again, and using the schema.Account object to create accounts instead