### PR TITLE
update proxy_read_timeout

### DIFF
--- a/packer/files/nginx-ssl.conf
+++ b/packer/files/nginx-ssl.conf
@@ -22,7 +22,7 @@ server {
         proxy_pass http://127.0.0.1:5000;
         proxy_redirect off;
         proxy_buffering off;
-        proxy_read_timeout 10s;
+        proxy_read_timeout 60s;
         proxy_cache off;
         expires off;
 


### PR DESCRIPTION
exporting large amounts of data takes longer than 10s, we need nginx to stop timing out while data is generated